### PR TITLE
Fixed panel fly back to snap position on close gesture

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -546,10 +546,18 @@ class _SlidingUpPanelState extends State<SlidingUpPanel>
       // snapPoint exists
       if (widget.panelSnapping && widget.snapPoint != null) {
         if (v.pixelsPerSecond.dy.abs() >= kSnap * minFlingVelocity ||
-            minDistance == d2Snap)
+            minDistance == d2Snap) {
           _ac.fling(velocity: visualVelocity);
-        else
-          _flingPanelToPosition(widget.snapPoint!, visualVelocity);
+        } else {
+          // if position is closest to close position
+          // and velocity is going in the close direction
+          if (visualVelocity < 0 && minDistance == d2Close) {
+            _close();
+          } else {
+            // go to snap position
+            _flingPanelToPosition(widget.snapPoint!, visualVelocity);
+          }
+        }
 
         // no snap point exists
       } else if (widget.panelSnapping) {


### PR DESCRIPTION
Cherry picked changes from [PR #319](https://github.com/akshathjain/sliding_up_panel/pull/319) to fix the issue where the panel flies back to the snap point, instead of the closed position, when flicking down (close gesture).